### PR TITLE
For ZIM metadata option "Language" use languages with a comma separator

### DIFF
--- a/lib/common.ts
+++ b/lib/common.ts
@@ -1,4 +1,12 @@
 import * as path from 'path';
+import {iso6393} from 'iso-639-3';
+
+const languageCodesMapping = {
+  fu: 'fur',
+  iw: 'heb',
+  in: 'ind',
+  mo: 'ron'
+};
 
 export const barOptions = {
     clearOnComplete: false,
@@ -9,4 +17,10 @@ export const barOptions = {
 export const getIdAndLanguage = (url: string): string[] => {
     if (!url) throw new Error('Got empty url');
     return /([^_]*)_([^]*)\./.exec(path.basename(url)).slice(1, 3);
+};
+
+export const getISO6393 = (lang = 'en') => {
+  lang = lang.split('_')[0];
+  const langEntity = iso6393.find(l => l.iso6391 === lang);
+  return langEntity ? langEntity.iso6393 : languageCodesMapping[lang];
 };

--- a/steps/export.ts
+++ b/steps/export.ts
@@ -6,13 +6,13 @@ import {promisify} from 'util';
 import rimraf from 'rimraf';
 import * as dotenv from 'dotenv';
 import * as cheerio from 'cheerio';
-import {iso6393} from 'iso-639-3';
 import {ZimArticle, ZimCreator} from '@openzim/libzim';
 
 import {log} from '../lib/logger.js';
 import {Target} from '../lib/types.js';
 import welcome from '../lib/welcome.js';
 import {Catalog} from '../lib/classes.js';
+import {getISO6393} from '../lib/common.js';
 import {Presets, SingleBar} from 'cli-progress';
 import {hideBin} from 'yargs/helpers';
 import { fileURLToPath } from 'url';
@@ -59,13 +59,6 @@ const namespaces = {
   html: 'A'
 };
 
-const languageCodesMapping = {
-  fu: 'fur',
-  iw: 'heb',
-  in: 'ind',
-  mo: 'ron'
-};
-
 const getNamespaceByExt = (ext: string): string => namespaces[ext] || '-';
 
 const getKiwixPrefix = (ext: string): string => `../${getNamespaceByExt(ext)}/`;
@@ -78,13 +71,6 @@ const addKiwixPrefixes = function addKiwixPrefixes(file) {
       return file.replace(resName, `${getKiwixPrefix(ext)}${resName}`);
     }, file);
 };
-
-const getISO6393 = (lang = 'en') => {
-  lang = lang.split('_')[0];
-  const langEntity = iso6393.find(l => l.iso6391 === lang);
-  return langEntity ? langEntity.iso6393 : languageCodesMapping[lang];
-};
-
 
 const extractResources = async (target, targetDir: string): Promise<void> => {
   const bar = new SingleBar({}, Presets.shades_classic);

--- a/steps/export.ts
+++ b/steps/export.ts
@@ -59,6 +59,13 @@ const namespaces = {
   html: 'A'
 };
 
+const languageCodesMapping = {
+  fu: 'fur',
+  iw: 'heb',
+  in: 'ind',
+  mo: 'ron'
+};
+
 const getNamespaceByExt = (ext: string): string => namespaces[ext] || '-';
 
 const getKiwixPrefix = (ext: string): string => `../${getNamespaceByExt(ext)}/`;
@@ -75,7 +82,7 @@ const addKiwixPrefixes = function addKiwixPrefixes(file) {
 const getISO6393 = (lang = 'en') => {
   lang = lang.split('_')[0];
   const langEntity = iso6393.find(l => l.iso6391 === lang);
-  if (langEntity) return langEntity.iso6393;
+  return langEntity ? langEntity.iso6393 : languageCodesMapping[lang];
 };
 
 
@@ -155,6 +162,8 @@ const exportTarget = async (target: Target, bananaI18n: Banana) => {
 
   const languageCode = target.languages.length > 1 ? 'mul' : getISO6393(target.languages[0]) || 'mul';
 
+  const iso6393LanguageCodes = target.languages.map(getISO6393);
+
   let locale = languageCode === 'mul' ? 'en' : target.languages[0];
   if(locale !== 'en') {
     const translations = await loadTranslations(locale);
@@ -177,7 +186,7 @@ const exportTarget = async (target: Target, bananaI18n: Banana) => {
     Description: bananaI18n.getMessage('zim-description'),
     Creator: 'University of Colorado',
     Publisher: 'Kiwix',
-    Language: languageCode,
+    Language: iso6393LanguageCodes.join(','),
     Date: `${target.date.getUTCFullYear()}-${(target.date.getUTCMonth() + 1).toString().padStart(2, '0')}-${target.date.getUTCDate().toString().padStart(2, '0')}`,
     Tags: '_category:phet;_pictures:yes;_videos:no',
     // the following two metadata keys don't supported by ZimCreator yet, so that we have to ts-ignore them

--- a/steps/get.ts
+++ b/steps/get.ts
@@ -14,7 +14,7 @@ import {log} from '../lib/logger.js';
 import {cats, rootCategories} from '../lib/const.js';
 import welcome from '../lib/welcome.js';
 import {SimulationsList} from '../lib/classes.js';
-import {barOptions} from '../lib/common.js';
+import {barOptions, getISO6393} from '../lib/common.js';
 import type {Category, LanguageDescriptor, LanguageItemPair, Meta, Simulation} from '../lib/types.js';
 import {hideBin} from 'yargs/helpers';
 
@@ -97,6 +97,10 @@ const fetchLanguages = async (): Promise<void> => {
 
     if (!Object.keys(languages)?.includes(slug)) {
       op.set(languages, slug, {slug, name, localName, url, count});
+    }
+
+    if(!getISO6393(slug)){
+      throw(new Error(`Failed to map language "${slug}" into ISO639-3.`));
     }
   });
   try {


### PR DESCRIPTION
With this PR the ZIM metadata option "Language" will not contain the "mul" value. Instead of the "mul" for multilanguage zim will be used list of languages with a comma separator.

Fix: #200 