### PR TITLE
Added command line parameter to not create zim for languages with variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ npm i && npm start
 The above will eventually output a ZIM file to ```dist/```
 
 ## Command line arguments
-`--withoutLanguageVariants` uses to exclude languages with County variant. For example `en_ca` will not be present in zim with this argument.
+`--withoutLanguageVariants` uses to exclude languages with Country variant. For example `en_CA` will not be present in zim with this argument.
 
 Available only on GET step:
 ```bash

--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ npm i && npm start
 The above will eventually output a ZIM file to ```dist/```
 
 ## Command line arguments
+`--withoutLanguageVariants` uses to exclude languages with County variant. For example `en_ca` will not be present in zim with this argument.
+
+Available only on GET step:
+```bash
+--withoutLanguageVariants ...
+```
+
 Available on GET and EXPORT steps only:
 ```bash
 --includeLanguages lang_1 [lang_2] [lang_3] ...

--- a/steps/get.ts
+++ b/steps/get.ts
@@ -82,6 +82,7 @@ const fetchLanguages = async (): Promise<void> => {
     const url = $(item).find('td.list-highlight-background:first-child a').attr('href')
     const slug = /locale=(.*)$/.exec(url)?.pop()
     if (argv.withoutLanguageVariants && slug.includes('_')) {
+      log.info(`Skipping ${slug} language`)
       return
     }
     const name = $(item).find('td.list-highlight-background:first-child a span').text()

--- a/steps/get.ts
+++ b/steps/get.ts
@@ -20,7 +20,7 @@ import { hideBin } from 'yargs/helpers'
 
 dotenv.config()
 
-const { argv } = yargs(hideBin(process.argv)).array('includeLanguages').array('excludeLanguages')
+const { argv } = yargs(hideBin(process.argv)).boolean('withoutLanguageVariants').array('includeLanguages').array('excludeLanguages')
 
 const failedDownloadsCountBeforeStop = 10
 const outDir = 'state/get/'
@@ -81,6 +81,9 @@ const fetchLanguages = async (): Promise<void> => {
   rows.forEach((item) => {
     const url = $(item).find('td.list-highlight-background:first-child a').attr('href')
     const slug = /locale=(.*)$/.exec(url)?.pop()
+    if (argv.withoutLanguageVariants && slug.includes('_')) {
+      return
+    }
     const name = $(item).find('td.list-highlight-background:first-child a span').text()
 
     const nativeLangName = ISO6391.getNativeName(slug)


### PR DESCRIPTION
Metadata `Language` is not supporting language with variants, for example, 'en_CA'.
With this PR added the command line parameter `--withoutLanguageVariants` which filters the language list and removes languages with variants.
This means that if the user uses the parameter `--withoutLanguageVariants` then zim files for languages with variants will not be created. 

Fix: #204 