### PR TITLE
Renamed the output file by adding _all after the language code

### DIFF
--- a/steps/export.ts
+++ b/steps/export.ts
@@ -248,7 +248,7 @@ const exportData = async () => {
 
   const targets: Target[] = [
     {
-      output: `phet_mul_${datePostfix}`,
+      output: `phet_mul_all_${datePostfix}`,
       date: now,
       languages: Object.keys(languages).filter((lang) => {
         const langCode = /^(\w{2})_/gm.exec(lang)?.pop()
@@ -259,7 +259,7 @@ const exportData = async () => {
   if (!argv.mulOnly) {
     for (const lang of Object.keys(languages)) {
       targets.push({
-        output: `phet_${lang.toLowerCase().replace('_', '-')}_${datePostfix}`,
+        output: `phet_${lang.toLowerCase().replace('_', '-')}_all_${datePostfix}`,
         date: now,
         languages: [lang],
       })

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -18,7 +18,7 @@ const targetDir = './dist/'
 
 const now = new Date()
 const datePostfix = `${now.getUTCFullYear()}-${(now.getUTCMonth() + 1).toString().padStart(2, '0')}`
-const files = [`${targetDir}phet_mul_${datePostfix}.zim`, `${targetDir}phet_${language}_${datePostfix}.zim`]
+const files = [`${targetDir}phet_mul_all_${datePostfix}.zim`, `${targetDir}phet_${language}_all_${datePostfix}.zim`]
 
 const options = {
   cwd: join(__dirname, '..'),


### PR DESCRIPTION
Using the same format of the file naming as used in `Name` metadata.

Fix: #205 