### PR TITLE
Use language with variants with biggest count of simulations. other should be removed.

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -16,6 +16,7 @@ export type Simulation = {
 
 export type LanguageDescriptor = {
   slug: string
+  langCode: string
   name: string
   localName: string
   url: string

--- a/steps/export/converters.ts
+++ b/steps/export/converters.ts
@@ -165,11 +165,11 @@ export const prepareTargets = () => {
     },
   ]
   if (!options.mulOnly) {
-    for (const lang of Object.keys(languages)) {
+    for (const { langCode, slug } of Object.values(languages)) {
       targets.push({
-        output: `phet_${lang.toLowerCase().replace('_', '-')}_all_${datePostfix}`,
+        output: `phet_${langCode.toLowerCase().replace('_', '-')}_all_${datePostfix}`,
         date: now,
-        languages: [lang],
+        languages: [slug],
       })
     }
   }

--- a/steps/export/utils.ts
+++ b/steps/export/utils.ts
@@ -10,6 +10,7 @@ import { log } from '../../lib/logger.js'
 import { Presets, SingleBar } from 'cli-progress'
 import { hideBin } from 'yargs/helpers'
 import { fileURLToPath } from 'url'
+import { LanguageDescriptor, LanguageItemPair } from '../../lib/types.js'
 
 dotenv.config()
 
@@ -52,7 +53,7 @@ export const rimrafPromised = promisify(rimraf)
 
 export const getNamespaceByExt = (ext: string): string => namespaces[ext] || '-'
 
-export const loadLanguages = async () => {
+export const loadLanguages = async (): Promise<LanguageItemPair<LanguageDescriptor>> => {
   const langsFile = await fs.promises.readFile(path.join(__dirname, '../../state/get/languages.json'))
   const langs = JSON.parse(langsFile.toString())
 


### PR DESCRIPTION
Changed logic to use --withoutLanguageVariants parameter.
When using --withoutLanguageVariants do not just remove languages with variants but use language with variants with the biggest count of simulations.
For example, if `ku` language has 41 simulations and `ku_TR` has 63 then for `ku` language use simulations from `ku_TR`. So in output, you will not see `ku_TR` but you will see `ku` with 63 simulations.

Fix: #207