### PR TITLE
build only files from res/js

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "export": "npm run export-prebuild && ts-node-esm -- steps/export/index.ts",
     "start": "npm run setup && npm run get && npm run transform && npm run export",
     "test": "npm run export-prebuild && node --experimental-vm-modules node_modules/jest/bin/jest.js --verbose --runInBand --forceExit",
-    "build": "tsc",
+    "build": "tsc --project tsconfig.build.json",
     "lint": "eslint -c .eslintrc.cjs --ext .ts .",
     "format": "prettier --write './**/*.ts'"
   },

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "res/js/**/*.ts"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,23 +1,20 @@
 {
-    "compilerOptions": {
-        "removeComments": false,
-        "preserveConstEnums": true,
-        "sourceMap": false,
-        "noImplicitAny": false,
-        "suppressImplicitAnyIndexErrors": true,
-        "allowJs": true,
-        "skipLibCheck": true,
-        "resolveJsonModule": true,
-        "module": "es2022",
-        "target": "es2022",
-        "lib": ["ES2021", "DOM"],
-        "moduleResolution": "Node",
-        "esModuleInterop": false,
-        "allowSyntheticDefaultImports": true,
-        "rootDir": ".",
-        "baseUrl": ".",
-    },
-    "files": [
-        "res/js/index.ts",
-    ]
+  "compilerOptions": {
+    "removeComments": false,
+    "preserveConstEnums": true,
+    "sourceMap": false,
+    "noImplicitAny": false,
+    "suppressImplicitAnyIndexErrors": true,
+    "allowJs": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "module": "es2022",
+    "target": "es2022",
+    "lib": ["ES2021", "DOM"],
+    "moduleResolution": "Node",
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "rootDir": ".",
+    "baseUrl": "."
+  }
 }


### PR DESCRIPTION
To execute Typescript from the command line we don't need to compile *.ts files into *.js files.
Before this PR, all *.ts files are compiled into *.js files.
Now only resource files from folder 'res/js' will be compiled into js.

fix: #187