### PR TITLE
By default, do not create mul ZIM

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -7,6 +7,7 @@ Unreleased:
 * FIX: Some simulations are failing to load with phet.chipper.localeData is undefined (#237)
 * UPDATE: Update to Node.JS 22 and upgrade dependencies (#243)
 * CHANGE: Stop removing third-party license information (#240)
+* CHANGED: By default, do not create mul ZIM (#242)
 
 2.5.0
 * FIX: Broken 2.4.0 version in Zimfarm (@pavel-karatsiuba #197 198)

--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ Available on EXPORT step only:
 ```bash
 # Skip ZIM files for individual languages
 --mulOnly
+
+# Create a ZIM file with all languages
+--createMul
 ```
 
 Example:

--- a/steps/export/converters.ts
+++ b/steps/export/converters.ts
@@ -157,16 +157,19 @@ export const prepareTargets = () => {
   const now = new Date()
   const datePostfix = `${now.getUTCFullYear()}-${(now.getUTCMonth() + 1).toString().padStart(2, '0')}`
 
-  const targets: Target[] = [
-    {
+  const targets: Target[] = []
+
+  if (options.mulOnly || options.createMul) {
+    targets.push({
       output: `phet_mul_all_${datePostfix}`,
       date: now,
       languages: Object.keys(languages).filter((lang) => {
         const langCode = /^(\w{2})_/gm.exec(lang)?.pop()
         return !langCode || !Object.keys(languages).includes(langCode)
       }),
-    },
-  ]
+    })
+  }
+
   if (!options.mulOnly) {
     for (const { langCode, slug } of Object.values(languages)) {
       targets.push({

--- a/steps/export/utils.ts
+++ b/steps/export/utils.ts
@@ -16,7 +16,7 @@ dotenv.config()
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 
-const argv: any = yargs(hideBin(process.argv)).array('includeLanguages').array('excludeLanguages').boolean('mulOnly').argv
+const argv: any = yargs(hideBin(process.argv)).array('includeLanguages').array('excludeLanguages').boolean('mulOnly').boolean('createMul').argv
 
 export const options = {
   catalogsDir: 'state/get/catalogs',
@@ -25,6 +25,7 @@ export const options = {
   resDir: 'res/',
   verbose: process.env.PHET_VERBOSE_ERRORS !== undefined ? process.env.PHET_VERBOSE_ERRORS === 'true' : false,
   mulOnly: argv.mulOnly,
+  createMul: argv.createMul,
 }
 
 export const loadLanguages = async (): Promise<LanguageItemPair<LanguageDescriptor>> => {

--- a/steps/parameterList.ts
+++ b/steps/parameterList.ts
@@ -3,4 +3,5 @@ export const parameterDescriptions = {
   excludeLanguages: 'Languages to exclude',
   withoutLanguageVariants: 'Exclude languages with Country variant. For example `en_CA` will not be present in zim with this argument.',
   mulOnly: 'Skip ZIM files for individual languages',
+  createMul: 'Create a ZIM file with all languages',
 }


### PR DESCRIPTION
We currently tend to prefer not creating `mul` ZIMs which are confusing to users. 

I feel like this scraper should at least support it, so I introduce a new CLI flag `--createMul` which must be set to create the `mul` ZIM. Hence by default we create only the ZIM corresponding to the `--includeLanguages` setting.

It was also weird to always have two ZIMs when you pass one single language to `--includeLanguages` (mul + requested language).