### PR TITLE
Stop removing third-party license information

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -6,6 +6,7 @@ Unreleased:
 * UPDATE: Upgrade to node-libzim 3.2.3 (libzim 9.2.1) (#239)
 * FIX: Some simulations are failing to load with phet.chipper.localeData is undefined (#237)
 * UPDATE: Update to Node.JS 22 and upgrade dependencies (#243)
+* CHANGE: Stop removing third-party license information (#240)
 
 2.5.0
 * FIX: Broken 2.4.0 version in Zimfarm (@pavel-karatsiuba #197 198)

--- a/steps/transform/utils.ts
+++ b/steps/transform/utils.ts
@@ -56,7 +56,6 @@ export const modifyHTML = async (fileName, html): Promise<string> => {
 }
 
 export const removeStrings = (html): string => {
-  html = html.replace(/(\/\/ This simulation uses following third-party resources.*?)(\/\/ ### END THIRD PARTY LICENSE ENTRIES ###)/gms, '$2')
   html = minifier.minify(html, { removeComments: true })
   return html
 }


### PR DESCRIPTION
Fix #240 

Remark:

- it has no visual impact at all, information is not shown to users
- size of `fr` ZIM jumped from 274M to 277M, which seems very acceptable 
