### PR TITLE
Use CMD instead of ENTRYPOINT for proper Zimfarm operation

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,4 +1,5 @@
 Unreleased
+* CHANGE: Use CMD instead of ENTRYPOINT for proper Zimfarm operation
 
 3.0.0
 * UPDATE: Upgrade to node-libzim 3.2.3 (libzim 9.2.1) (#239)

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,5 +22,5 @@ COPY .babelrc /phet
 # Install phets scrapper
 RUN npm run export-prebuild && npm install && npm link
 
-ENTRYPOINT ["phet2zim"]
+CMD ["phet2zim"]
 


### PR DESCRIPTION
Zimfarm does not expects an ENTRYPOINT in scrapers, so we are better with a simple CMD, just like all other scrapers.