### PR TITLE
Fix handling of many locale languages

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -2,6 +2,11 @@ Unreleased
 * FIX: Fix responsivness (#260)
 * FIX: Lazy load home page images
 * FIX: stop loading simulation when clicking in the backdrop (outside) of the popup
+* FIX: Add support for ku_TR, only has a variant
+* FIX: Sort language combobox in UI by locale language name alphabetical order
+* FIX: Include all variants in mul ZIM, not only the ones for which there is only variants
+* FIX: Add fallback for slug without known locale language name (#261)
+* FIX: Remove English name property on language descriptors: property is unused and missing on variants
 
 3.0.2
 * FIX: Fix compression of documents (#256)

--- a/lib/common.ts
+++ b/lib/common.ts
@@ -1,5 +1,6 @@
 import * as path from 'path'
 import { iso6393 } from 'iso-639-3'
+import ISO6391 from 'iso-639-1'
 
 const languageCodesMapping = {
   fu: 'fur',
@@ -8,6 +9,33 @@ const languageCodesMapping = {
   mo: 'ron',
   sp: 'nso',
   ef: 'efi',
+}
+
+const languagesNativesMapping = {
+  ar_KW: 'العربية (الكويت)',
+  ar_KY: 'العربية (ليبيا)',
+  ar_SY: 'العربية (سوريا)',
+  ar_MA: 'العربية (المغرب)',
+  ar_SA: 'العربية (السعودية)',
+  en_CA: 'English (Canada)',
+  en_GB: 'English (United Kingdom)',
+  ef: 'Usem Efịk',
+  es_UY: 'español (Uruguay)',
+  es_CO: 'español (Colombia)',
+  es_MX: 'español (México)',
+  es_PE: 'español (Perú)',
+  es_ES: 'español (España)',
+  fa_DA: 'دری',
+  in: 'Bahasa Indonesia',
+  iw: 'עברית',
+  ku_tr: 'Kurmancî',
+  mo: '	Moldavian',
+  pt_br: 'português (Brasil)',
+  sh: '	Serbo-Croatian',
+  sp: 'Sesotho sa Leboa',
+  zh_CN: '中文 (中国)',
+  zh_HK: '中文 (香港)',
+  zh_TW: '中文 (台灣)',
 }
 
 export const barOptions = {
@@ -25,4 +53,8 @@ export const getISO6393 = (lang = 'en') => {
   lang = lang.split('_')[0]
   const langEntity = iso6393.find((l) => l.iso6391 === lang)
   return langEntity ? langEntity.iso6393 : languageCodesMapping[lang]
+}
+
+export const getNativeName = (lang: string) => {
+  return languagesNativesMapping[lang] || ISO6391.getNativeName(lang)
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -17,7 +17,6 @@ export type Simulation = {
 export type LanguageDescriptor = {
   slug: string
   langCode: string
-  name: string
   localName: string
   url: string
   count: number

--- a/res/js/index.ts
+++ b/res/js/index.ts
@@ -106,7 +106,7 @@ declare global {
     template: reactiveTemplate,
     computed: {
       languages() {
-        return Object.entries(this.get('languageMappings'))
+        return Object.entries(this.get('languageMappings')).sort((a, b) => (a[1] as string).localeCompare(b[1] as string))
       },
       updateCategories() {
         const lang = this.get('selectedLanguage')

--- a/steps/export/converters.ts
+++ b/steps/export/converters.ts
@@ -162,10 +162,7 @@ export const prepareTargets = () => {
     targets.push({
       output: `phet_mul_all_${datePostfix}`,
       date: now,
-      languages: Object.keys(languages).filter((lang) => {
-        const langCode = /^(\w{2})_/gm.exec(lang)?.pop()
-        return !langCode || !Object.keys(languages).includes(langCode)
-      }),
+      languages: Object.keys(languages),
     })
   }
 

--- a/steps/get/fetchers.ts
+++ b/steps/get/fetchers.ts
@@ -41,7 +41,6 @@ export const fetchMetaAndLanguages = async (): Promise<void> => {
 
     const url = `https://phet.colorado.edu/en/simulations/filter?locale=${slug}&type=html`
 
-    const name = ISO6391.getName(slug)
     const localName = ISO6391.getNativeName(slug)
 
     const count = selectedProjects
@@ -57,7 +56,7 @@ export const fetchMetaAndLanguages = async (): Promise<void> => {
       const langCode = slug.split('_')[0]
       if (slug === 'zh_CN') {
         log.info(`Using ${slug} simulations for ${langCode} language`)
-        op.set(languages, slug, { slug, langCode, name, localName, url, count })
+        op.set(languages, slug, { slug, langCode, localName, url, count })
         return
       }
 
@@ -65,7 +64,7 @@ export const fetchMetaAndLanguages = async (): Promise<void> => {
       if (existedLanguageKey && languages[existedLanguageKey].count < count) {
         delete languages[existedLanguageKey]
         log.info(`Using ${slug} simulations for ${langCode} language`)
-        op.set(languages, slug, { slug, langCode, name, localName, url, count })
+        op.set(languages, slug, { slug, langCode, localName, url, count })
       } else {
         log.info(`Skipping ${slug} language`)
       }
@@ -73,7 +72,7 @@ export const fetchMetaAndLanguages = async (): Promise<void> => {
     }
 
     if (!Object.keys(languages)?.includes(slug)) {
-      op.set(languages, slug, { slug, name, localName, url, count, langCode: slug })
+      op.set(languages, slug, { slug, localName, url, count, langCode: slug })
     }
   })
   try {

--- a/steps/get/fetchers.ts
+++ b/steps/get/fetchers.ts
@@ -57,7 +57,7 @@ export const fetchMetaAndLanguages = async (): Promise<void> => {
 
     if (options.withoutLanguageVariants && slug.includes('_')) {
       const langCode = slug.split('_')[0]
-      if (slug === 'zh_CN') {
+      if (slug === 'zh_CN' || slug === 'ku_TR') {
         log.info(`Using ${slug} simulations for ${langCode} language`)
         op.set(languages, slug, { slug, langCode, localName, url, count })
         return

--- a/steps/get/fetchers.ts
+++ b/steps/get/fetchers.ts
@@ -4,12 +4,11 @@ import * as path from 'path'
 import slugify from 'slugify'
 import op from 'object-path'
 import * as cheerio from 'cheerio'
-import ISO6391 from 'iso-639-1'
 import { Presets, SingleBar } from 'cli-progress'
 import { log } from '../../lib/logger.js'
 import { cats, rootCategories } from '../../lib/const.js'
 import { SimulationsList } from '../../lib/classes.js'
-import { barOptions, getISO6393 } from '../../lib/common.js'
+import { barOptions, getISO6393, getNativeName } from '../../lib/common.js'
 import type { Category, LanguageDescriptor, LanguageItemPair, Meta, Simulation } from '../../lib/types.js'
 import options from './options.js'
 import { popValueUpIfExists, delay, downloadCatalogData } from './utils.js'
@@ -41,8 +40,6 @@ export const fetchMetaAndLanguages = async (): Promise<void> => {
 
     const url = `https://phet.colorado.edu/en/simulations/filter?locale=${slug}&type=html`
 
-    const localName = ISO6391.getNativeName(slug)
-
     const count = selectedProjects
       .map((project) => project.simulations)
       .reduce((acc, sims) => acc.concat(sims), [])
@@ -51,6 +48,12 @@ export const fetchMetaAndLanguages = async (): Promise<void> => {
 
     if (options.includeLanguages && !((options.includeLanguages as string[]) || []).includes(slug)) return
     if (options.excludeLanguages && ((options.excludeLanguages as string[]) || []).includes(slug)) return
+
+    const localName = getNativeName(slug)
+
+    if (!localName) {
+      throw new Error(`Failed to get native language name of "${slug}"`)
+    }
 
     if (options.withoutLanguageVariants && slug.includes('_')) {
       const langCode = slug.split('_')[0]


### PR DESCRIPTION
To be reviewed / merged after #262 

Fix #261 and many other issues

Changes:
* FIX: Add support for `ku_TR`, which is a language which only has a variant, just like `zh_CN`
* FIX: Sort language combobox in UI by locale language name alphabetical order
* FIX: Include all variants in mul ZIM, not only the ones for which there is only variants
* FIX: Add fallback for slug without known locale language name (#261)
* FIX: Remove English name property on language descriptors: property is unused and missing on variants