### PR TITLE
feat: Standardize output folder and added --output option to cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ jspm_packages
 
 state
 dist/*
+output
 ts-node*
 .env
 res/js/i18n/*.js

--- a/Changelog
+++ b/Changelog
@@ -7,6 +7,7 @@ Unreleased
 * FIX: Include all variants in mul ZIM, not only the ones for which there is only variants
 * FIX: Add fallback for slug without known locale language name (#261)
 * FIX: Remove English name property on language descriptors: property is unused and missing on variants
+* NEW: Standardize output folder and add option to CLI (#248)
 
 3.0.2
 * FIX: Fix compression of documents (#256)

--- a/README.md
+++ b/README.md
@@ -27,11 +27,16 @@ It requires Node.js version 16 or higher.
 npm i && phet2zim
 ```
 
-The above will eventually output a ZIM file to ```dist/```
+The above will eventually output a ZIM file to ```output/```
 
 ## Command line arguments
 
 See `phet2zim --help` for details.
+
+`phet2zim --output` generates ZIM files in a specific folder.
+```bash
+phet2zim --output ZimFarm
+```
 
 `--withoutLanguageVariants` uses to exclude languages with Country variant. For example `en_CA` will not be present in zim with this argument.
 

--- a/steps/cli.ts
+++ b/steps/cli.ts
@@ -2,7 +2,7 @@
 
 import yargs from 'yargs'
 import { hideBin } from 'yargs/helpers'
-import { parameterDescriptions } from './parameterList'
+import { parameterDescriptions, applyParameterConstraints } from './parameterList'
 import { spawn } from 'child_process'
 
 /** **********************************/
@@ -21,6 +21,7 @@ yargs(hideBin(process.argv))
 Usage: phet2zim --help`,
   )
   .describe(parameterDescriptions)
+  .check(applyParameterConstraints)
   .strict().argv
 
 /** **********************************/

--- a/steps/export/converters.ts
+++ b/steps/export/converters.ts
@@ -19,6 +19,7 @@ const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 
 const languages = await loadLanguages()
+const zimOutDir = options.zimOutDir || 'output'
 
 export const loadTranslations = async (locale: string) => {
   try {
@@ -77,8 +78,11 @@ export const exportTarget = async (target: Target, bananaI18n: Banana) => {
 
   log.info(`Creating ${target.output}.zim ...`)
 
+  await fs.promises.mkdir(`${zimOutDir}`, { recursive: true })
+  log.info(`Output to ${zimOutDir}/ directory`)
+
   const creator = new Creator()
-  creator.configIndexing(true, iso6393LanguageCode).configCompression(Compression.Zstd).startZimCreation(`./dist/${target.output}.zim`)
+  creator.configIndexing(true, iso6393LanguageCode).configCompression(Compression.Zstd).startZimCreation(`./${zimOutDir}/${target.output}.zim`)
 
   creator.setMainPath('index.html')
 

--- a/steps/export/utils.ts
+++ b/steps/export/utils.ts
@@ -16,7 +16,7 @@ dotenv.config()
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 
-const argv: any = yargs(hideBin(process.argv)).array('includeLanguages').array('excludeLanguages').boolean('mulOnly').boolean('createMul').argv
+const argv: any = yargs(hideBin(process.argv)).string('output').array('includeLanguages').array('excludeLanguages').boolean('mulOnly').boolean('createMul').argv
 
 export const options = {
   catalogsDir: 'state/get/catalogs',
@@ -26,6 +26,7 @@ export const options = {
   verbose: process.env.PHET_VERBOSE_ERRORS !== undefined ? process.env.PHET_VERBOSE_ERRORS === 'true' : false,
   mulOnly: argv.mulOnly,
   createMul: argv.createMul,
+  zimOutDir: argv.output,
 }
 
 export const loadLanguages = async (): Promise<LanguageItemPair<LanguageDescriptor>> => {

--- a/steps/parameterList.ts
+++ b/steps/parameterList.ts
@@ -4,4 +4,12 @@ export const parameterDescriptions = {
   withoutLanguageVariants: 'Exclude languages with Country variant. For example `en_CA` will not be present in zim with this argument.',
   mulOnly: 'Skip ZIM files for individual languages',
   createMul: 'Create a ZIM file with all languages',
+  output: 'Output ZIM files in a specific directory',
+}
+
+export const applyParameterConstraints = (argv): boolean => {
+  if (argv.output && Array.isArray(argv.output)) {
+    throw new Error(`Error: duplicate --output isn't allowed.`)
+  }
+  return true
 }


### PR DESCRIPTION
Fix [#248](https://github.com/openzim/phet/issues/248)

Changes :
- Updated parameters list to include `output`.
- Update `options` that are needed in the exporting step/phase.
I found out that you're handling CLI options/parameters in the relevant step/phase ... e.g: 'get' options are handled in the 'get' step such as `--withoutLanguageVariants`. So, I decided to handle `--output` in the 'export' step.
- Ensure that value of  `--output` is a single value before running scripts.
- Updated README file
- Updated `.gitignore`

Notes :
- I didn't remove `dist/` from `.gitignore`; since i don't know if we're using somewhere in the codebase.
- I was thinking of making some validation on the value of output such as preventing user from creating hidden folder, but i thought it would be strict. 

So, tell me if I misunderstand something or there are things to be enhanced.