### PR TITLE
Support --subjects as csv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Support csv for --includeLanguages and --excludeLanguages and split values by ',' (#257)
+* Support --subjects option and csv format for input (#271)
 
 ## [3.1.0] - 2025-03-31
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ See `phet2zim --help` for details.
 
 `--withoutLanguageVariants` uses to exclude languages with Country variant. For example `en_CA` will not be present in zim with this argument.
 
+`--subjects` is used to pass specific subjects to download. Pass values as csv. Sample of valid subjects : 
+```
+physics, biology, earth-science, motion, sound-and-waves, work-energy-and-power, heat-and-thermodynamics, quantum-phenomena
+```
+
 Available only on GET step:
 ```bash
 --withoutLanguageVariants ...
@@ -44,6 +49,7 @@ Available on GET and EXPORT steps only:
 ```bash
 --includeLanguages 'lang_1,lang_2,lang_3' ...
 --excludeLanguages 'lang_1,lang_2,lang_3' ...
+--subjects 'math,physics' ...
 ```
 
 Available on EXPORT step only:

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -30,6 +30,7 @@ export type Target = {
   output: string
   date: Date
   languages: string[]
+  subjects: string[]
 }
 
 export type LocalizedSimulation = {

--- a/steps/export/converters.ts
+++ b/steps/export/converters.ts
@@ -160,18 +160,20 @@ export const prepareTargets = () => {
 
   if (options.mulOnly || options.createMul) {
     targets.push({
-      output: `phet_mul_all_${datePostfix}`,
+      output: `phet_mul_${options.all ? 'all' : Object.values(options.cats).join('_')}_${datePostfix}`,
       date: now,
       languages: Object.keys(languages),
+      subjects: Object.values(options.cats),
     })
   }
 
   if (!options.mulOnly) {
     for (const { langCode, slug } of Object.values(languages)) {
       targets.push({
-        output: `phet_${langCode.toLowerCase().replace('_', '-')}_all_${datePostfix}`,
+        output: `phet_${langCode.toLowerCase().replace('_', '-')}_${options.all ? 'all' : Object.values(options.cats).join('_')}_${datePostfix}`,
         date: now,
         languages: [slug],
+        subjects: Object.values(options.cats),
       })
     }
   }

--- a/steps/export/utils.ts
+++ b/steps/export/utils.ts
@@ -10,14 +10,14 @@ import { hideBin } from 'yargs/helpers'
 import { fileURLToPath } from 'url'
 import { LanguageDescriptor, LanguageItemPair } from '../../lib/types.js'
 import { ContentProvider, Blob } from '@openzim/libzim/dist/index.js'
-import { formatLanguages } from 'steps/utils.js'
+import { formatLanguages, getMatchedCats } from 'steps/utils.js'
 
 dotenv.config()
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 
-const argv: any = yargs(hideBin(process.argv)).string('includeLanguages').string('excludeLanguages').boolean('mulOnly').boolean('createMul').argv
+const argv: any = yargs(hideBin(process.argv)).string('includeLanguages').string('excludeLanguages').boolean('mulOnly').boolean('createMul').string('subjects').argv
 
 export const options = {
   catalogsDir: 'state/get/catalogs',
@@ -27,6 +27,8 @@ export const options = {
   verbose: process.env.PHET_VERBOSE_ERRORS !== undefined ? process.env.PHET_VERBOSE_ERRORS === 'true' : false,
   mulOnly: argv.mulOnly,
   createMul: argv.createMul,
+  all: argv.subjects ? false : true,
+  cats: getMatchedCats(argv.subjects),
 }
 
 export const loadLanguages = async (): Promise<LanguageItemPair<LanguageDescriptor>> => {

--- a/steps/get/fetchers.ts
+++ b/steps/get/fetchers.ts
@@ -189,11 +189,7 @@ export const fetchCatalogsWithUrls = async (bar) => {
       if (project.type !== 2) return
       for (const sim of Object.values(project.simulations)) {
         // exclude sim that doesn't match --subjects values
-        let neededSim = false
-        sim.subjects.forEach((subjectId) => {
-          if (Object.keys(cats).includes(`${subjectId}`)) neededSim = true
-        })
-        if (!neededSim) continue
+        if (!sim.subjects.some((subjectId) => cats.hasOwnProperty(`${subjectId}`))) continue
 
         for (const [lang, { title }] of Object.entries(sim.localizedSimulations)) {
           if (!Object.keys(simsTree)?.includes(lang)) continue

--- a/steps/get/fetchers.ts
+++ b/steps/get/fetchers.ts
@@ -6,12 +6,14 @@ import op from 'object-path'
 import * as cheerio from 'cheerio'
 import { Presets, SingleBar } from 'cli-progress'
 import { log } from '../../lib/logger.js'
-import { cats, rootCategories } from '../../lib/const.js'
 import { SimulationsList } from '../../lib/classes.js'
 import { barOptions, getISO6393, getNativeName } from '../../lib/common.js'
 import type { Category, LanguageDescriptor, LanguageItemPair, Meta, Simulation } from '../../lib/types.js'
-import options from './options.js'
+import options, { categories } from './options.js'
 import { popValueUpIfExists, delay, downloadCatalogData } from './utils.js'
+
+const cats = categories.cats
+const rootCategories = categories.rootCats
 
 const languages: LanguageItemPair<LanguageDescriptor> = {}
 let meta: Meta
@@ -21,7 +23,12 @@ const categoriesList: LanguageItemPair<any> = {}
 export const fetchMetaAndLanguages = async (): Promise<void> => {
   meta = JSON.parse((await got('services/metadata/1.3/simulations?format=json&summary', { ...options.gotOptions })).body)
   // Filter projects we want to consider
-  const selectedProjects = meta.projects.filter(({ type }) => type === 2)
+  const selectedProjects = meta.projects.filter(({ type, simulations }) => {
+    const isMatchedSubj = simulations.every((sim) => {
+      return sim.subjects.some((subID) => Object.keys(cats).includes(`${subID}`))
+    })
+    return isMatchedSubj && type === 2
+  })
 
   const langSlugs = Array.from(
     new Set(
@@ -181,6 +188,13 @@ export const fetchCatalogsWithUrls = async (bar) => {
     Object.values(meta.projects).map(async (project) => {
       if (project.type !== 2) return
       for (const sim of Object.values(project.simulations)) {
+        // exclude sim that doesn't match --subjects values
+        let neededSim = false
+        sim.subjects.forEach((subjectId) => {
+          if (Object.keys(cats).includes(`${subjectId}`)) neededSim = true
+        })
+        if (!neededSim) continue
+
         for (const [lang, { title }] of Object.entries(sim.localizedSimulations)) {
           if (!Object.keys(simsTree)?.includes(lang)) continue
 

--- a/steps/get/options.ts
+++ b/steps/get/options.ts
@@ -1,11 +1,12 @@
 import yargs from 'yargs'
 import * as dotenv from 'dotenv'
 import { hideBin } from 'yargs/helpers'
-import { formatLanguages } from 'steps/utils'
+import { formatLanguages, formatSubjects, getMatchedCats } from 'steps/utils'
+import { cats, rootCategories } from 'lib/const'
 
 dotenv.config()
 
-const { argv } = yargs(hideBin(process.argv)).boolean('withoutLanguageVariants').string('includeLanguages').string('excludeLanguages')
+const { argv } = yargs(hideBin(process.argv)).boolean('withoutLanguageVariants').string('includeLanguages').string('excludeLanguages').string('subjects')
 
 const defaultOptions = {
   failedDownloadsCountBeforeStop: 10,
@@ -40,4 +41,9 @@ export default {
       ...(process.env.PHET_RETRIES ? { limit: parseInt(process.env.PHET_RETRIES, 10) } : {}),
     },
   },
+}
+
+export const categories = {
+  rootCats: argv.subjects ? formatSubjects(argv.subjects) : rootCategories,
+  cats: argv.subjects ? getMatchedCats(argv.subjects) : cats,
 }

--- a/steps/parameterList.ts
+++ b/steps/parameterList.ts
@@ -1,4 +1,4 @@
-import { formatLanguages } from './utils'
+import { formatLanguages, verifySubjects } from './utils'
 
 export const parameterDescriptions = {
   includeLanguages: 'Languages to include',
@@ -6,6 +6,7 @@ export const parameterDescriptions = {
   withoutLanguageVariants: 'Exclude languages with Country variant. For example `en_CA` will not be present in zim with this argument.',
   mulOnly: 'Skip ZIM files for individual languages',
   createMul: 'Create a ZIM file with all languages',
+  subjects: `List of subjects to download. Use csv format (e.g 'math,physics')`,
 }
 
 export const applyParameterConstraints = (argv): boolean => {
@@ -16,5 +17,6 @@ export const applyParameterConstraints = (argv): boolean => {
   if (argv.excludeLanguages) {
     if (!formatLanguages(argv.excludeLanguages).every((lang: string) => languageRegex.test(lang))) throw new Error(`--excludeLanguages must follow this format 'en, pt_BR, ar'`)
   }
+  if (argv.subjects && !verifySubjects(argv.subjects)) throw new Error(`--subjects must include valid subjects formated in csv`)
   return true
 }

--- a/steps/utils.ts
+++ b/steps/utils.ts
@@ -1,3 +1,32 @@
+import slugify from 'slugify'
+import { cats } from 'lib/const'
+
+const formatcsv = (inputs: string): string[] => {
+  return inputs.split(',').map((input) => input.trim())
+}
+
 export const formatLanguages = (langs: string): string[] => {
-  return langs.split(',').map((lang) => lang.trim())
+  return formatcsv(langs)
+}
+
+export const formatSubjects = (subjects: string): string[] => {
+  return formatcsv(subjects)
+}
+
+export const verifySubjects = (subjects: string): boolean => {
+  const validSubjects = Object.values(cats)
+  return formatSubjects(subjects).every((subj) => validSubjects.includes(slugify(subj, { lower: true })))
+}
+
+export const getMatchedCats = (input: string) => {
+  const formatedSubjects = formatSubjects(input)
+  const catsKeys = Object.keys(cats)
+  const catsValues = Object.values(cats)
+  const validCats = {}
+
+  formatedSubjects.forEach((sub) => {
+    const indexCat = catsValues.indexOf(slugify(sub, { lower: true }))
+    if (indexCat >= 0) validCats[catsKeys[indexCat]] = catsValues[indexCat]
+  })
+  return validCats
 }


### PR DESCRIPTION
Fix : [#271](https://github.com/openzim/phet/issues/271)

Approach:
- Add `--subjects` to parameterList as a CLI option
- Verify that passed subjects are valid and match with `rootCategories` and `cats`
- Select both `cats` and `rootCategories`  values based on passed values.

e.g : `--subjects 'math, physics'`
- `cats : {4: 'physics', 15: 'math'}`
- `rootCategories : [Math, Physics]`
- simTree (if en,mo passed as includeLangauges):
```
en: {
    'atomic-interactions': [ 'Physics' ],
    'balancing-act': [ 'Physics', 'Math' ],
    .....
}

 mo: {
    'atomic-interactions': [ 'Physics' ],
    'balancing-act': [ 'Physics', 'Math' ],
    ......
}
```

Note:
- I have added `formatcsv` as a util function for all future csv parameters.