### PR TITLE
Deduplicate ZIM Name by using unique PhET code in ZIM Name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Correctly use ISO639 codes in ZIM Name and ZIM filename, and align both (#308)
 * Fix --includeLanguages in export function (#308)
 * Workaround bad code inside few upstream HTML pages (#314)
+* Deduplicate ZIM Name by using unique PhET code in ZIM Name (#307)
 
 ## [3.1.0] - 2025-03-31
 

--- a/steps/export/converters.ts
+++ b/steps/export/converters.ts
@@ -9,7 +9,6 @@ import { getISO6393 } from '../../lib/common.js'
 import { Presets, SingleBar } from 'cli-progress'
 import { catalogJs } from '../../res/templates/catalog.js'
 import Banana from 'banana-i18n'
-import { iso6393To1 } from 'iso-639-3'
 import { options, extractResources, loadLanguages, createFileContentProvider } from './utils.js'
 import { rimraf } from 'rimraf'
 import { fileURLToPath } from 'url'
@@ -34,12 +33,13 @@ export const loadTranslations = async (locale: string) => {
 }
 
 export const exportTarget = async (target: Target, bananaI18n: Banana) => {
-  const iso6393LanguageCode = target.languages.length > 1 ? 'mul' : getISO6393(target.languages[0]) || 'mul'
-  const iso6391LanguageCode = target.languages.length > 1 ? 'mul' : iso6393To1[iso6393LanguageCode] || iso6393LanguageCode
+  const mainIso6393LanguageCode = target.languages.length > 1 ? 'mul' : getISO6393(target.languages[0]) || 'mul'
+  const zimnameLanguageCode = target.languages.length > 1 ? 'mul' : target.languages[0]
 
   const iso6393LanguageCodes = target.languages.map(getISO6393)
 
-  const filename = `phet_${iso6391LanguageCode}_${target.selection}_${target.datePostfix}`
+  const zimname = `phet_${zimnameLanguageCode}_${target.selection}`
+  const filename = `${zimname}_${target.datePostfix}`
 
   const catalog = new Catalog({ target, languages, catalogsDir: options.catalogsDir })
   await catalog.init()
@@ -69,7 +69,7 @@ export const exportTarget = async (target: Target, bananaI18n: Banana) => {
       .map(async (file) => fs.promises.copyFile(file, `${targetDir}${path.basename(file)}`)),
   )
 
-  let locale = iso6393LanguageCode === 'mul' ? 'en' : target.languages[0]
+  let locale = target.languages.length > 1 ? 'en' : target.languages[0]
   if (locale !== 'en') {
     const translations = await loadTranslations(locale)
 
@@ -84,12 +84,12 @@ export const exportTarget = async (target: Target, bananaI18n: Banana) => {
   log.info(`Output to '${zimOutDir}' directory`)
 
   const creator = new Creator()
-  creator.configIndexing(true, iso6393LanguageCode).configCompression(Compression.Zstd).startZimCreation(`${zimOutDir}/${filename}.zim`)
+  creator.configIndexing(true, mainIso6393LanguageCode).configCompression(Compression.Zstd).startZimCreation(`${zimOutDir}/${filename}.zim`)
 
   creator.setMainPath('index.html')
 
   const metadata = {
-    Name: `phets_${iso6391LanguageCode}_all`,
+    Name: zimname,
     Title: bananaI18n.getMessage('zim-title'),
     Description: bananaI18n.getMessage('zim-description'),
     Creator: 'University of Colorado',


### PR DESCRIPTION
Decision made in https://github.com/openzim/phet/issues/308 to use ISO-639-1 or use ISO-639-3 in ZIM Name is wrong.

Since we have no control on which code PhET uses / will use, this decision will inevitably cause collisions we would have to manually handle.

Hence:
- since the ZIM Name is not supposed to be interpreted (extract language from name)
- since PhET has its own definition of which codes it wants
- since PhET code is de-facto unique
- since `Language` metadata is correct (`ron` for `mo` for instance)

This PR proposes to use the PhET language inside the ZIM Name. This seems to be the only sustainable choice in the long run, and it does not break any convention (we only recommend to use ISO639 in the ZIM name).

This has the added benefit to not change existing recipes filenames, avoiding painful maintenance once released.

Fix #307