### PR TITLE
Ensure we do not add a full-text index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix --includeLanguages in export function (#308)
 * Workaround bad code inside few upstream HTML pages (#314)
 * Deduplicate ZIM Name by using unique PhET code in ZIM Name (#307)
+* Ensure we do not add a full-text index (#97)
 
 ## [3.1.0] - 2025-03-31
 

--- a/steps/export/converters.ts
+++ b/steps/export/converters.ts
@@ -84,7 +84,9 @@ export const exportTarget = async (target: Target, bananaI18n: Banana) => {
   log.info(`Output to '${zimOutDir}' directory`)
 
   const creator = new Creator()
-  creator.configIndexing(true, mainIso6393LanguageCode).configCompression(Compression.Zstd).startZimCreation(`${zimOutDir}/${filename}.zim`)
+  creator.configIndexing(false, target.languages.length > 1 ? 'eng' : mainIso6393LanguageCode)
+  creator.configCompression(Compression.Zstd)
+  creator.startZimCreation(`${zimOutDir}/${filename}.zim`)
 
   creator.setMainPath('index.html')
 


### PR DESCRIPTION
Fix #97 

I confirm the fact we did not had a full-text index was only accidental in that libzim did not achieved to extract interesting content from the HTML file provided.

With this PR:
- full-text index is turned off, no matter what libzim might find in 
- suggestion search is still on
- I've fixed language used for stemming of suggestion search (passed `eng` instead of `mul`)