### PR TITLE
fix: remove Cloudflare beacon.min.js external dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Add mappings for pr and ua languages (#325)
 * Fix ZIM name (and filename) when we have a language with variants (#326)
+* Remove external dependencies to Cloudflare beacon and Google Tag Manager scripts injected into simulation HTML files (#323)
 
 ## [3.1.1] - 2026-02-27
 

--- a/steps/transform/utils.ts
+++ b/steps/transform/utils.ts
@@ -30,7 +30,12 @@ export const modifyHTML = async (fileName, html): Promise<string> => {
       .each((indx, elem: cheerio.Element) => {
         const script = $(elem).html().trim()
         const scriptId = $(elem).attr('id')
-        if ((scriptId && scriptId.search('google-analytics') > -1) || script.search('google-analytics.com') > -1) {
+        if ((scriptId && scriptId.search('google-analytics') > -1) || script.search('google-analytics.com') > -1 || script.search('googletagmanager.com') > -1) {
+          $(elem).remove()
+          return
+        }
+        const scriptSrc = $(elem).attr('src')
+        if (scriptSrc && scriptSrc.includes('static.cloudflareinsights.com')) {
           $(elem).remove()
           return
         }


### PR DESCRIPTION
Fixes #323

  The transform step was not stripping the Cloudflare analytics script injected by the CDN into downloaded simulation HTML files:

   `<script defer src="https://static.cloudflareinsights.com/beacon.min.js/..."></script>`

This caused zimcheck to report a url_external ERROR since ZIM files must be fully self-contained with no external dependencies.