### PR TITLE
Add mappings for pr and ua languages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+* Add mappings for pr and ua languages (#325)
+
 ## [3.1.1] - 2026-02-27
 
 ### Added

--- a/lib/common.ts
+++ b/lib/common.ts
@@ -9,6 +9,8 @@ const languageCodesMapping = {
   mo: 'ron',
   sp: 'nso',
   ef: 'efi',
+  pr: 'tsz',
+  ua: 'nhe',
 }
 
 const languagesNativesMapping = {
@@ -36,6 +38,8 @@ const languagesNativesMapping = {
   zh_CN: '中文 (中国)',
   zh_HK: '中文 (香港)',
   zh_TW: '中文 (台灣)',
+  ua: 'Náhuatl',
+  pr: 'Pʼurhépecha',
 }
 
 export const barOptions = {


### PR DESCRIPTION
`pr` and `ua` languages were still not mapped correctly. This is fixed with this PR.