### PR TITLE
Fix ZIM name (and filename) when we have a language with variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Add mappings for pr and ua languages (#325)
+* Fix ZIM name (and filename) when we have a language with variants (#326)
 
 ## [3.1.1] - 2026-02-27
 

--- a/steps/export/converters.ts
+++ b/steps/export/converters.ts
@@ -34,7 +34,13 @@ export const loadTranslations = async (locale: string) => {
 
 export const exportTarget = async (target: Target, bananaI18n: Banana) => {
   const mainIso6393LanguageCode = target.languages.length > 1 ? 'mul' : getISO6393(target.languages[0]) || 'mul'
-  const zimnameLanguageCode = target.languages.length > 1 ? 'mul' : target.languages[0]
+  const zimnameLanguageCode =
+    target.languages.length > 1
+      ? 'mul'
+      : target.languages[0]
+          .toLowerCase()
+          .replace(/[^a-z-]/g, '-')
+          .replace(/-+/g, '-')
 
   const iso6393LanguageCodes = target.languages.map(getISO6393)
 


### PR DESCRIPTION
When we use `--includeLanguages zh_CN`, it gives a `phet_zh_CN_all` name which is incorrect, should be `phet_zh-cn_all` to match our convention.