### PR TITLE
Rollback workaround for bad HTML code in upstream PhET simulations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* Rollback workaround for bad HTML code in upstream PhET simulations, now fixed upstream (#316)
 * Add mappings for pr and ua languages (#325)
 * Fix ZIM name (and filename) when we have a language with variants (#326)
 * Remove external dependencies to Cloudflare beacon and Google Tag Manager scripts injected into simulation HTML files (#323)

--- a/steps/get/fetchers.ts
+++ b/steps/get/fetchers.ts
@@ -11,7 +11,6 @@ import { barOptions, getISO6393, getNativeName, withoutVariantsOverrides } from 
 import type { Category, LanguageDescriptor, LanguageItemPair, Meta, Simulation } from '../../lib/types.js'
 import options, { categories } from './options.js'
 import { popValueUpIfExists, delay, downloadCatalogData } from './utils.js'
-import { Transform } from 'stream'
 
 const cats = categories.cats
 const rootCategories = categories.rootCats
@@ -303,24 +302,7 @@ export const fetchSims = async (): Promise<void> => {
           resolve()
         })
 
-        // Temporary transform to workaround https://github.com/openzim/phet/issues/314
-        // Only apply to HTML files, not binary files like PNG
-        const filterStream = new Transform({
-          transform(chunk, encoding, callback) {
-            const content = chunk
-              .toString()
-              .split('\n')
-              .filter((line: string) => !line.includes('<<<<<<< HEAD'))
-              .join('\n')
-            callback(null, content)
-          },
-        })
-
-        const isHtmlFile = fileName.endsWith('.html')
-
-        const pipeChain = isHtmlFile ? data.pipe(filterStream) : data
-
-        pipeChain
+        data
           .on('response', function (response) {
             if (simsToDelete.length > options.failedDownloadsCountBeforeStop) {
               reject(new Error(`Stopped because the count of failed simulation downloads is higher than ${options.failedDownloadsCountBeforeStop}.`))


### PR DESCRIPTION
Closes #316 

The temporary workaround added in #315 is taken off. The upstream issue (phetsims/chipper#1663) has since been fixed by the PhET team — the bad markers are no longer present in the live HTML files. 

@benoit74 Review this PR at your convenience. Thanks